### PR TITLE
Resolved bug where there was a missing `run` parameter in `npm run test-ci` in `node.js-with-docker-db.yml`

### DIFF
--- a/.github/workflows/node.js-with-docker-db.yml
+++ b/.github/workflows/node.js-with-docker-db.yml
@@ -65,7 +65,7 @@ jobs:
         shell: bash
         run: docker-compose up --file ./.github/ci/docker-compose-test-ci-db-only.yml up --build --detach
       - name: Running test cases
-        run: npm test-ci
+        run: npm run test-ci
         env:
           PORT: ${{ secrets.PORT }}
           TEST_MONGODB_URI: mongodb://root:password@mongo:27017/softwareRepositoryTest?authSource=admin


### PR DESCRIPTION
- Resolved bug where there was a missing `run` parameter in `npm run test-ci` in `node.js-with-docker-db.yml`