### PR TITLE
Added `/api/search/software` API endpoint to allow for searching of software in database

### DIFF
--- a/app.js
+++ b/app.js
@@ -4,14 +4,13 @@ const morgan = require('morgan');
 const cors = require('cors');
 const mongoose = require('mongoose');
 const config = require('./utils/config');
-
-const rootRouter = require('./routes/root');
-const usersRouter = require('./routes/api/users');
-
 const middleware = require('./utils/middleware');
 const logger = require('./utils/logger');
+const rootRouter = require('./routes/root');
+const usersRouter = require('./routes/api/users');
 const authRouter = require('./routes/api/auth');
 const softwareRouter = require('./routes/api/software');
+const searchRouter = require('./routes/api/search');
 
 const app = express();
 
@@ -61,6 +60,7 @@ app.use(rootRouter);
 app.use('/api/users', usersRouter);
 app.use('/api/auth', authRouter);
 app.use('/api/software', softwareRouter);
+app.use('/api/search', searchRouter);
 
 app.use(middleware.unknownEndPoint);
 app.use(middleware.errorHandler);

--- a/controllers/api/searchController.js
+++ b/controllers/api/searchController.js
@@ -1,0 +1,16 @@
+const Software = require('../../models/software');
+
+const searchSoftware = async (req, res) => {
+  const { name } = req.query;
+  const response = await Software.find({
+    name: {
+      $regex: name,
+      $options: 'i',
+    },
+  });
+  return res.status(200).json(response);
+};
+
+module.exports = {
+  searchSoftware,
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -1172,8 +1172,7 @@
     "@tootallnate/once": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-1.1.2.tgz",
-      "integrity": "sha512-RbzJvlNzmRq5c3O09UipeuXno4tA1FE6ikOjxZK0tuxVv3412l64l5t1W5pj4+rJq9vpkm/kwiR07aZXnsKPxw==",
-      "optional": true
+      "integrity": "sha512-RbzJvlNzmRq5c3O09UipeuXno4tA1FE6ikOjxZK0tuxVv3412l64l5t1W5pj4+rJq9vpkm/kwiR07aZXnsKPxw=="
     },
     "@types/babel__core": {
       "version": "7.1.14",
@@ -1456,7 +1455,6 @@
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
       "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
-      "optional": true,
       "requires": {
         "debug": "4"
       },
@@ -1465,7 +1463,6 @@
           "version": "4.3.1",
           "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
           "integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
-          "optional": true,
           "requires": {
             "ms": "2.1.2"
           }
@@ -1473,8 +1470,7 @@
         "ms": {
           "version": "2.1.2",
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-          "optional": true
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
         }
       }
     },
@@ -3767,7 +3763,6 @@
           "version": "4.3.1",
           "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
           "integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
-          "optional": true,
           "requires": {
             "ms": "2.1.2"
           }
@@ -3775,8 +3770,7 @@
         "ms": {
           "version": "2.1.2",
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-          "optional": true
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
         }
       }
     },
@@ -3793,7 +3787,6 @@
           "version": "4.3.1",
           "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
           "integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
-          "optional": true,
           "requires": {
             "ms": "2.1.2"
           }
@@ -3801,8 +3794,7 @@
         "ms": {
           "version": "2.1.2",
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-          "optional": true
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
         }
       }
     },
@@ -7821,8 +7813,7 @@
     "yallist": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-      "optional": true
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
     "yargs": {
       "version": "16.2.0",

--- a/requests/api/softwares/search_software.rest
+++ b/requests/api/softwares/search_software.rest
@@ -1,0 +1,1 @@
+GET http://localhost:3001/api/search/software?name=sample

--- a/routes/api/search.js
+++ b/routes/api/search.js
@@ -1,0 +1,6 @@
+const searchRouter = require('express').Router();
+const searchController = require('../../controllers/api/searchController');
+
+searchRouter.get('/software', searchController.searchSoftware);
+
+module.exports = searchRouter;


### PR DESCRIPTION
- Added `/api/search/software` API endpoint to allow for searching of software in database
- Added test search software API endpoint `search_software.rest` file

This is to prepare for usage in frontend typeahead search bar

**Note**: This does not use `mongodb` build in [`text search`](https://docs.mongodb.com/manual/text-search/) due to lack of support for partial text search.

The current implementation involves using `regexp`.

## Potential Alternatives to `regexp` implementation:
- To use `Mongodb Atlas Search`: [Link 1](https://www.mongodb.com/atlas/search), [Link 2](https://www.mongodb.com/blog/post/mongodb-atlas-search-now-ga) but it will mean require depending on a third party service.
- To use `elasticsearch`: [Link](https://www.elastic.co/what-is/elasticsearch)