### PR TITLE
Resolved breaking changes in migration to mongoose version 6

### DIFF
--- a/app.js
+++ b/app.js
@@ -17,12 +17,7 @@ const app = express();
 
 // To establish connection to database
 mongoose
-  .connect(config.MONGODB_URI, {
-    useNewUrlParser: true,
-    useUnifiedTopology: true,
-    useCreateIndex: true,
-    useFindAndModify: false,
-  })
+  .connect(config.MONGODB_URI)
   .then(() => {
     logger.info('App successfully connected to MongoDB');
   })

--- a/controllers/api/softwareController.js
+++ b/controllers/api/softwareController.js
@@ -4,15 +4,16 @@ const User = require('../../models/user');
 const databaseUtils = require('../../utils/databaseUtils');
 
 const getSoftware = async (req, res) => {
-  const softwares = await Software.find({})
-    .populate('meta.addedByUser', {
-      username: 1,
-      name: 1,
-    })
-    .populate('meta.updatedByUser', {
-      username: 1,
-      name: 1,
-    });
+  const softwares = await Software.find({}).populate([
+    {
+      path: 'meta.addedByUser',
+      select: 'username name',
+    },
+    {
+      path: 'meta.updatedByUser',
+      select: 'username name',
+    },
+  ]);
   res.status(200).json(softwares);
 };
 
@@ -40,22 +41,21 @@ const postSoftware = async (req, res) => {
   user.contributions.softwaresAdded = user.contributions.softwaresAdded.concat(
     savedSoftware._id,
   );
-  user.contributions.softwaresContributed = user.contributions.softwaresContributed.concat(
-    savedSoftware._id,
-  );
+  user.contributions.softwaresContributed =
+    user.contributions.softwaresContributed.concat(savedSoftware._id);
 
   await user.save();
 
-  const saved = await savedSoftware
-    .populate('meta.addedByUser', {
-      username: 1,
-      name: 1,
-    })
-    .populate('meta.updatedByUser', {
-      username: 1,
-      name: 1,
-    })
-    .execPopulate();
+  const saved = await savedSoftware.populate([
+    {
+      path: 'meta.addedByUser',
+      select: 'username name',
+    },
+    {
+      path: 'meta.updatedByUser',
+      select: 'username name',
+    },
+  ]);
 
   return res.status(201).json(saved);
 };
@@ -89,16 +89,21 @@ const patchSoftwareById = async (req, res) => {
   const user = await User.findById(userId);
 
   if (!user.contributions.softwaresContributed.includes(id)) {
-    user.contributions.softwaresContributed = user.contributions.softwaresContributed.concat(
-      updatedSoftware._id,
-    );
+    user.contributions.softwaresContributed =
+      user.contributions.softwaresContributed.concat(updatedSoftware._id);
     await user.save();
   }
 
-  const updated = await updatedSoftware
-    .populate('meta.addedByUser', { username: 1, name: 1 })
-    .populate('meta.updatedByUser', { username: 1, name: 1 })
-    .execPopulate();
+  const updated = await updatedSoftware.populate([
+    {
+      path: 'meta.addedByUser',
+      select: 'username name',
+    },
+    {
+      path: 'meta.updatedByUser',
+      select: 'username name',
+    },
+  ]);
 
   return res.status(200).json(updated);
 };
@@ -112,10 +117,16 @@ const getSoftwareById = async (req, res) => {
     return res.status(404).end();
   }
 
-  const response = await software
-    .populate('meta.addedByUser', { username: 1, name: 1 })
-    .populate('meta.updatedByUser', { username: 1, name: 1 })
-    .execPopulate();
+  const response = await software.populate([
+    {
+      path: 'meta.addedByUser',
+      select: 'username name',
+    },
+    {
+      path: 'meta.updatedByUser',
+      select: 'username name',
+    },
+  ]);
 
   return res.status(200).json(response);
 };

--- a/controllers/api/usersController.js
+++ b/controllers/api/usersController.js
@@ -3,13 +3,16 @@ const firebaseAdmin = require('../../utils/firebaseConfig');
 const jwtUtils = require('../../utils/jwtUtils');
 
 const getUsers = async (req, res) => {
-  const users = await User.find({})
-    .populate('contributions.softwaresAdded', {
-      name: 1,
-    })
-    .populate('contributions.softwaresContributed', {
-      name: 1,
-    });
+  const users = await User.find({}).populate([
+    {
+      path: 'contributions.softwaresAdded',
+      select: 'name',
+    },
+    {
+      path: 'contributions.softwaresContributed',
+      select: 'name',
+    },
+  ]);
   return res.json(users);
 };
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1408,7 +1408,6 @@
           "version": "4.3.1",
           "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
           "integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
-          "optional": true,
           "requires": {
             "ms": "2.1.2"
           }
@@ -1416,8 +1415,7 @@
         "ms": {
           "version": "2.1.2",
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-          "optional": true
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
         }
       }
     },
@@ -3768,7 +3766,6 @@
           "version": "4.3.1",
           "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
           "integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
-          "optional": true,
           "requires": {
             "ms": "2.1.2"
           }
@@ -3776,8 +3773,7 @@
         "ms": {
           "version": "2.1.2",
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-          "optional": true
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
         }
       }
     },
@@ -7517,8 +7513,7 @@
     "yallist": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-      "optional": true
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
     "yargs": {
       "version": "16.2.0",


### PR DESCRIPTION
- Resolved breaking changes in migration to `mongoose` version `6`
- Refactored source code to remove deprecated options in mongoose version 6 such as `useNewUrlParser`, `useUnifiedTopology`, `useFindAndModify` and `useCreateIndex`
- Refactored source code to switch from the removed `execPopulate()` method

Resolved issue #253 