### PR TITLE
Added `ProcFile` for Heroku backup deployment support

### DIFF
--- a/ProcFile
+++ b/ProcFile
@@ -1,0 +1,1 @@
+web: npm start


### PR DESCRIPTION
- Added `ProcFile` for Heroku backup deployment support

**Note**: This is to add Heroku as a backup deployment in case Microsoft Azure server is not working such as due to free resource quota limitation